### PR TITLE
Self-evaluate closure passed to assert()

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -267,7 +267,7 @@ class Node {
         node = node.parent;
       assert(node != child); // indicates we are about to create a cycle
       return true;
-    });
+    }());
 
     _childrenNeedSorting = true;
     _children.add(child);


### PR DESCRIPTION
In Dart 2.0, only boolean values will be accepted by assert. Closures were previously accepted, but should simply self-evaluate now.

https://github.com/dart-lang/sdk/issues/30326