### PR TITLE
Fix: example/fitness, latest flutter (1.5.4) is not compatible with gradle version 2.2.3

### DIFF
--- a/example/fitness/android/build.gradle
+++ b/example/fitness/android/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven {
             url "https://maven.google.com"
@@ -28,5 +30,5 @@ task clean(type: Delete) {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
+    gradleVersion = '3.2.1'
 }


### PR DESCRIPTION
Fix: example/fitness, latest flutter (1.5.4) is not compatible with gradle version 2.2.3 Changed gradle version to 3.2.1