### PR TITLE
Fix for breaking change in ImageStream in Flutter v1.6.2.

### DIFF
--- a/lib/src/image_map.dart
+++ b/lib/src/image_map.dart
@@ -24,12 +24,14 @@ class ImageMap {
   Future<ui.Image> loadImage(String url) async {
     ImageStream stream = new AssetImage(url, bundle: _bundle).resolve(ImageConfiguration.empty);
     Completer<ui.Image> completer = new Completer<ui.Image>();
-    void listener(ImageInfo frame, bool synchronousCall) {
+    ImageStreamListener listener;
+    listener = new ImageStreamListener(
+    (ImageInfo frame, bool synchronousCall) {
       final ui.Image image = frame.image;
       _images[url] = image;
       completer.complete(image);
       stream.removeListener(listener);
-    }
+    });
     stream.addListener(listener);
     return completer.future;
   }


### PR DESCRIPTION
Spritewidget was not able to compile after Flutter v1.6.2 due to a breaking change in ImageStream. See this link: https://groups.google.com/forum/#!topic/flutter-announce/NWTszrEq9U0