### PR TITLE
Assigning SpriteBoxes to child trees

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -255,6 +255,14 @@ class Node {
     return true;
   }
 
+  // Assign _spriteBox recursively to a child tree
+  void _assignSpriteBoxToChild(Node child) {
+    child._spriteBox = _spriteBox;
+    for (var grandChild in child.children) {
+      _assignSpriteBoxToChild(grandChild);
+    }
+  }
+
   // Adding and removing children
 
   /// Adds a child to this node.
@@ -269,7 +277,9 @@ class Node {
     _childrenNeedSorting = true;
     _children.add(child);
     child._parent = this;
-    child._spriteBox = _spriteBox;
+
+    _assignSpriteBoxToChild(child);
+
     _childrenLastAddedOrder += 1;
     child._addedOrder = _childrenLastAddedOrder;
     if (_spriteBox != null) _spriteBox!._registerNode(child);


### PR DESCRIPTION
In my game I add children in the constructor of dynamically added parent node classes. Currently this pattern is not possible when those child nodes uses operations that depends on their underlying SpriteBox, since only the parent node gets the SpriteBox assigned when it is added.

This fixes it. Perhaps a bit of a bandaid solution to a bigger problem. You decide if it's worth it.